### PR TITLE
Extend list of words, all words with comma

### DIFF
--- a/correct_endings.py
+++ b/correct_endings.py
@@ -6,8 +6,11 @@ import argparse
 LIST_OF_WORDS = ["a", "i", "o", "u", "w", "z", "ze", "od", "do", "że", "iż",
                  "poprzez", "przez", "spod", "sponad", "znad", "po", "za", "nad", "pod", "na",
                  "oraz", "ale", "lub", "albo", "bądź", "czy", "by", "aby", "jak", "ponieważ", "bo",
-                 "który", "która", "które", "którego", "któremu", "której", "którym"]
+                 "który", "która", "które", "którego", "któremu", "której", "którym",
+                 "to", "te", "są", "się", "dla", "jest", "być", "lecz", "wraz", "nie", "tak", 
+                 "więc", "niech", "tylko"]
 
+LIST_OF_WORDS = LIST_OF_WORDS + [word + "," for word in LIST_OF_WORDS]
 
 def add_hard_spaces(path_to_tex_files):
     global LIST_OF_WORDS


### PR DESCRIPTION
This PR extends `LIST_OF_WORDS` list with new common words that shouldn't be placed at the end of line, which I encountered while writing my engineering thesis. 

Also, all this words should be checked together with comma after them. This is done by adding all these words with appended comma at the end (line 13)